### PR TITLE
Suggestion to move the details from the FAQ to the main api guide

### DIFF
--- a/vipps-report-api-faq.md
+++ b/vipps-report-api-faq.md
@@ -27,7 +27,7 @@ END_METADATA -->
 
 <!-- END_TOC -->
 
-Document version: 0.0.4.
+Document version: 0.0.5.
 
 ## When will the API be available?
 
@@ -40,48 +40,15 @@ and make sure we are developing the right solution.
 ## Which API keys give access to the API?
 
 In short: The following API keys give access to the Report API:
-* The merchant's own API keys: The same API keys that are used to make payments.
-* Partner keys: The same API keys that are used to make payments.
-* Accounting partners' API keys: The API keys provided to the accounting partner
-  when the partner signed a contract with Vipps. The accounting partner's
-  API keys only work for sale units after the merchant has
-  [given access to the accounting partner](vipps-report-api#give-access-to-an-accounting-partner).
 
-### The merchant's own API keys
+* Using the merchant's own API keys for the sale unit.
+* Using the partner's API keys, called
+  [partner keys](https://vippsas.github.io/vipps-developer-docs/docs/vipps-partner/#partner-keys).
+* Using the Accounting partners' API keys.
 
-The merchant's own API keys give full access to the Report API.
-
-If the merchant uses an integration partner (see
-[partner types](https://vippsas.github.io/vipps-developer-docs/docs/vipps-partner/#partner-types)),
-it is the same as using the merchant's own API keys.
-
-When a merchant shares its API keys for a sale unit with an integration partner,
-Vipps has no way of knowing whether the API calls are made by the merchant or
-the integration partner.
-This is why we require that all API requests made by a partner on behalf of a
-merchant are done using the partner's own API keys (the partner keys).
-
-### Partner keys
-
-If the merchant has a sale unit that is configured with a platform partner (see
-[partner types](https://vippsas.github.io/vipps-developer-docs/docs/vipps-partner/#partner-types)),
-the platform partner can use
-[partner keys](https://vippsas.github.io/vipps-developer-docs/docs/vipps-partner/partner-keys)
-to make requests to the Report API.
-
-[Partner keys](https://vippsas.github.io/vipps-developer-docs/docs/vipps-partner/partner-keys)
-lets a partner make payments on behalf of a merchant, and the same API keys
-also give access to the Report API.
-
-### Specifying a accounting partner
-
-In addition to the above, the merchant may add one or more accounting partners.
-An accounting partner will get access to the Report API, but will not be allowed
-to make payments, or move money in any way. The accounting partner can only see
-reports of the payments that have been made.
-
-See:
-[Give access to an accounting partner](vipps-report-api#give-access-to-an-accounting-partner)
+See
+[Authenticating to the Report API](./vipps-report-api.md#authenticating-to-the-report-api)
+for more details.
 
 ## Questions?
 

--- a/vipps-report-api-settlement-guide.md
+++ b/vipps-report-api-settlement-guide.md
@@ -4,15 +4,13 @@ title: "API Guide: Settlements"
 sidebar_position: 7
 ---
 END_METADATA -->
-
+# Vipps Report API: Settlements
 <!-- START_COMMENT -->
 
 ℹ️ Please use the new documentation:
 [Vipps Technical Documentation](https://vippsas.github.io/vipps-developer-docs/).
 
 <!-- END_COMMENT -->
-
-# Vipps Report API: Settlements
 
 <!-- START_TOC -->
 
@@ -31,7 +29,7 @@ END_METADATA -->
 
 <!-- END_TOC -->
 
-Document version: 0.0.6.
+Document version: 0.0.7.
 
 ## Overview
 
@@ -77,8 +75,8 @@ Vippsnummer or e-com Merchant Serial Number (MSNs) to a ledger:
 
 ![ledger vs units, one to one](./images/ledger-vs-units-one-to-one.png)
 
-However, for merchants who require it, Vipps have
-limited support for multiple Vippsnummers/e-com MSNs to be settled together.
+However, for merchants who require it, Vipps has
+limited support for multiple Vipps numbers/ecom MSNs to be settled together.
 The payments to multiple different units are then combined in a
 single settlement payout:
 
@@ -163,6 +161,7 @@ to the merchant through Vipps. Reservations are not relevant to
 the settlement process.
 
 ### Refund transactions
+
 Refunds represent transfers in the other direction. These are
 initiated by the merchant; either by using the API or
 through [portal.vipps.no](https://portal.vipps.no). Refunds are always deducted
@@ -246,7 +245,7 @@ calling
 [`GET:/report/v1/ledgers/{ledgerId}/transactions`](https://vippsas.github.io/vipps-developer-docs/api/report#/paths/~1v1~1ledgers~1%7BledgerId%7D~1transactions/get),
 for instance:
 
-```
+```HTTP
 GET https://api.vipps.no/report/v1/ledgers/302321/transactions?ledgerDate=2022-10-01&columns=transactionId,transactionType,reference,ledgerDate,ledgerAmount,grossAmount,fee,msn,time,price.description
 ```
 
@@ -254,7 +253,7 @@ The endpoint can return either CSV or JSON depending on the `Accept` header;
 both always contain the exactly same data just in different representations. An
 example CSV response for the call above that matches the illustration above:
 
-```
+```csv
 transactionId,transactionType,reference,ledgerDate,ledgerAmount,grossAmount,fee,msn,time,price.description
 3343121302,capture,purchase-12,2022-10-01,97.00,100.00,3.00,123455,2022-10-01T10:23:43.422143+02:00,3.00% + 0.00
 2342128799,capture,purchase-12,2022-10-01,97.00,100.00,3.00,123455,2022-10-01T11:04:12.234234+02:00,3.00% + 0.00

--- a/vipps-report-api-settlement-guide.md
+++ b/vipps-report-api-settlement-guide.md
@@ -52,8 +52,9 @@ processes.
 ## Ledgers
 
 Vipps settlements work in the same way for all Vipps payment products; whether
-one is using Vippsnummer, the eCom/ePayment API, the Checkout API or the
-Recurring API.
+one is using
+[Vippsnummer](https://vipps.no/produkter-og-tjenester/bedrift/ta-betalt-i-butikk/ta-betalt-med-vipps/#kom-i-gang)
+or one of the Vipps APIs.
 
 Vipps does not transfer money to/from the merchant for every payment made.
 Instead, all transactions are put on a *ledger*
@@ -76,7 +77,7 @@ Vippsnummer or e-com Merchant Serial Number (MSNs) to a ledger:
 ![ledger vs units, one to one](./images/ledger-vs-units-one-to-one.png)
 
 However, for merchants who require it, Vipps has
-limited support for multiple Vipps numbers/ecom MSNs to be settled together.
+limited support for multiple Vippsnummer and eCom MSNs to be settled together.
 The payments to multiple different units are then combined in a
 single settlement payout:
 

--- a/vipps-report-api.md
+++ b/vipps-report-api.md
@@ -58,7 +58,7 @@ There are currently three ways to connect to the Report API:
 
 * The merchant's own API keys: The same API keys that are used to make payments.
 * Partner keys: The same API keys that are used to make payments.
-* Accounting partners' API keys: The API keys provided to the accounting partner
+* Accounting partner's API keys: The API keys provided to the accounting partner
   when the partner signed a contract with Vipps. The accounting partner's
   API keys only work for sale units after the merchant has
   [given access to the accounting partner](vipps-report-api#give-access-to-an-accounting-partner).

--- a/vipps-report-api.md
+++ b/vipps-report-api.md
@@ -18,21 +18,21 @@ END_METADATA -->
 
 ## Table of contents
 
-- [About the Report API](#about-the-report-api)
-- [Authenticating to the Report API](#authenticating-to-the-report-api)
-  - [Using the merchant's API keys](#using-the-merchants-api-keys)
-  - [Using the partner's partner keys](#using-the-partners-partner-keys)
-- [About report endpoints](#about-report-endpoints)
-  - [CSV vs JSON](#csv-vs-json)
-- [Field/column documentation](#fieldcolumn-documentation)
-- [Give access to an accounting partner](#give-access-to-an-accounting-partner)
-  - [Overview of accounting partners](#overview-of-accounting-partners)
-  - [Adding a new accounting partner](#adding-a-new-accounting-partner)
-- [Questions?](#questions)
+* [About the Report API](#about-the-report-api)
+* [Authenticating to the Report API](#authenticating-to-the-report-api)
+  * [Using the merchant's API keys](#using-the-merchants-api-keys)
+  * [Using the partner's partner keys](#using-the-partners-partner-keys)
+* [About report endpoints](#about-report-endpoints)
+  * [CSV vs JSON](#csv-vs-json)
+* [Field/column documentation](#fieldcolumn-documentation)
+* [Give access to an accounting partner](#give-access-to-an-accounting-partner)
+  * [Overview of accounting partners](#overview-of-accounting-partners)
+  * [Adding a new accounting partner](#adding-a-new-accounting-partner)
+* [Questions?](#questions)
 
 <!-- END_TOC -->
 
-Document version: 0.0.6.
+Document version: 0.0.7.
 
 ## About the Report API
 
@@ -41,11 +41,10 @@ aggregate information across APIs, and reports containing data for many
 payments at once.
 
 This document contains common traits of the entire API.
-We also have guides for specific usecases:
+We also have guides for specific use cases:
 
 * [Settlement guide](vipps-report-api-settlement-guide.md) explains the settlement process and the Ledger
 * Coming later: Endpoints for recent/non-settled transactions.
-
 
 **Please note:** The information fetched from the Report API is
 asynchronous and trailing behind the other APIs. Usually it is behind
@@ -56,6 +55,7 @@ Vipps APIs as the source of truth for the status of an operation.
 ## Authenticating to the Report API
 
 There are currently two ways to connect to the Report API:
+
 * Using the merchant's own API keys for the sale unit.
 * Using the partner's API keys, called
   [partner keys](https://vippsas.github.io/vipps-developer-docs/docs/vipps-partner/#partner-keys).
@@ -89,7 +89,6 @@ downloading a full report in one go. We will not time out a
 request server side, so it is OK if the download takes several
 minutes and is multiple megabytes. We may provide features
 for downloading in *pages* of data at a later point.
-
 
 ### CSV vs JSON
 
@@ -141,7 +140,6 @@ The only difference is that in JSON, the fields do not have a given
 order and that the distinction between numbers and strings disappear in CSV.
 JSON sub-structures become dotted column names in CSV.
 
-
 ## Field/column documentation
 
 This table lists all of the fields (or columns, in CSV) available for
@@ -165,8 +163,8 @@ TODO: Add the missing documentation.
 | transactionId     | Numeric ID |                                                                                 |
 | transactionType   | String     | See [transaction types](vipps-report-api-settlement-guide.md#transaction-types) |
 | ledgerDate        |            |                                                                                 |
-| ledgerAmount      |            |                                                                                 |      
-| grossAmount       |            |                                                                                 |  
+| ledgerAmount      |            |                                                                                 |
+| grossAmount       |            |                                                                                 |
 | fee               |            |                                                                                 |
 | msn               |            |                                                                                 |
 | time              |            |                                                                                 |
@@ -183,7 +181,7 @@ A merchant may have zero or more accounting partners. This page on
 [portal.vipps.no](https://portal.vipps.no)
 shows the accounting partners for one sale unit.
 
-![Overview over accounting-partners](./images/portal-regnskapspartnere-oversikt.png "Regnskapspartner oversikt")
+![Overview over accounting-partners](./images/portal-regnskapspartnere-oversikt.png "Accounting Partners overview")
 
 ### Adding a new accounting partner
 
@@ -192,7 +190,7 @@ This page on
 shows how to add an accounting partners, and how to specify which ledgers the
 accounting partner will have access to.
 
-![Add a new accounting-partner](./images/portal-regnskapspartnere-legg-til.png "Regnskapspartner oversikt")
+![Add a new accounting-partner](./images/portal-regnskapspartnere-legg-til.png "Add a new accounting partner")
 
 ## Questions?
 

--- a/vipps-report-api.md
+++ b/vipps-report-api.md
@@ -43,7 +43,7 @@ payments at once.
 This document contains common traits of the entire API.
 We also have guides for specific use cases:
 
-* [Settlement guide](vipps-report-api-settlement-guide.md) explains the settlement process and the Ledger
+* [Settlement guide](vipps-report-api-settlement-guide.md) explains the settlement process and the ledger
 * Coming later: Endpoints for recent/non-settled transactions.
 
 **Please note:** The information fetched from the Report API is
@@ -54,27 +54,60 @@ Vipps APIs as the source of truth for the status of an operation.
 
 ## Authenticating to the Report API
 
-There are currently two ways to connect to the Report API:
+There are currently three ways to connect to the Report API:
 
-* Using the merchant's own API keys for the sale unit.
-* Using the partner's API keys, called
-  [partner keys](https://vippsas.github.io/vipps-developer-docs/docs/vipps-partner/#partner-keys).
+* The merchant's own API keys: The same API keys that are used to make payments.
+* Partner keys: The same API keys that are used to make payments.
+* Accounting partners' API keys: The API keys provided to the accounting partner
+  when the partner signed a contract with Vipps. The accounting partner's
+  API keys only work for sale units after the merchant has
+  [given access to the accounting partner](vipps-report-api#give-access-to-an-accounting-partner).
 
 See:
-[Getting started: Get an access token](https://vippsas.github.io/vipps-developer-docs/docs/vipps-developers/vipps-getting-started#get-an-access-token).
+[Getting started: Get an access token](https://vippsas.github.io/vipps-developer-docs/docs/vipps-developers/vipps-getting-started#get-an-access-token) for more details about authentication in the Vipps APIs.
 
-### Using the merchant's API keys
+### Using the merchant's own API keys
 
 Individual merchants that have API keys
-for using the eCom/ePayment APIs may use this to access a single
-Ledger connected to the sale unit (identified with MSN). If there
-is more than one sale unit connected to the Ledger, access will be denied.
+for using the Vipps APIs may use this to access a single
+ledger connected to the sale unit (identified with MSN). If there
+is more than one sale unit connected to the ledger, access will be denied.
 
-### Using the partner's partner keys
+If the merchant uses an integration partner (see
+[partner types](https://vippsas.github.io/vipps-developer-docs/docs/vipps-partner/#partner-types)),
+it is the same as using the merchant's own API keys.
+
+When a merchant shares its API keys for a sale unit with an integration partner,
+Vipps has no way of knowing whether the API calls are made by the merchant or
+the integration partner.
+This is why we require that all API requests made by a partner on behalf of a
+merchant are done using the partner's own API keys (the partner keys).
+
+### Using the partner's own keys
 
 Partner API users do not have access to any ledgers by default. Such
 access must be granted by the merchant:
 [Adding a new accounting partner](#adding-a-new-accounting-partner).
+
+If the merchant has a sale unit that is configured with a platform partner (see
+[partner types](https://vippsas.github.io/vipps-developer-docs/docs/vipps-partner/#partner-types)),
+the platform partner can use
+[partner keys](https://vippsas.github.io/vipps-developer-docs/docs/vipps-partner/partner-keys)
+to make requests to the Report API.
+
+[Partner keys](https://vippsas.github.io/vipps-developer-docs/docs/vipps-partner/partner-keys)
+lets a partner make payments on behalf of a merchant, and the same API keys
+also give access to the Report API.
+
+### Specifying a accounting partner
+
+In addition to the above, the merchant may add one or more accounting partners.
+An accounting partner will get access to the Report API, but will not be allowed
+to make payments, or move money in any way. The accounting partner can only see
+reports of the payments that have been made.
+
+See:
+[Give access to an accounting partner](vipps-report-api#give-access-to-an-accounting-partner)
 
 ## About report endpoints
 


### PR DESCRIPTION
I feel like people will read the main guide first and they need to understand these concepts, so this should be in the api guide with a link from the FAQ...