### PR TITLE
Fix error in flowchart for Multi-MSN-to-Ledger

### DIFF
--- a/api-guide/settlement.md
+++ b/api-guide/settlement.md
@@ -96,7 +96,7 @@ single settlement payout:
 flowchart LR
     Customer1([Customer])
     Customer2([Customer])
-    Customer1-- Payments -->ecomMSN1[eCom MSN 800002]
+    Customer1-- Payments -->ecomMSN1[eCom MSN 800001]
     Customer2-- Payments -->ecomMSN2[eCom MSN 800002]
     ecomMSN1 --> Ledger["Ledger #quot;Acme Central Clearing#quot;"]
     ecomMSN2 --> Ledger


### PR DESCRIPTION
The MSNs in the flowchart are identical, which defeats the purpose of the example. 
Was different in pre-mermaid chart.