### PR TITLE
Post 375 add standards vipps headers to swagger

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -42,6 +42,10 @@ paths:
 
       parameters:
         - $ref: "#/components/parameters/JWT"
+        - $ref: '#/components/parameters/Vipps-System-Name'
+        - $ref: '#/components/parameters/Vipps-System-Version'
+        - $ref: '#/components/parameters/Vipps-System-Plugin-Name'
+        - $ref: '#/components/parameters/Vipps-System-Plugin-Version'
         - in: query
           name: settlesForRecipientHandles
           required: false
@@ -110,7 +114,11 @@ paths:
         Returns a list of payments/transactions.
       parameters:
         - $ref: "#/components/parameters/JWT"
-        - in: path
+        - $ref: '#/components/parameters/Vipps-System-Name'
+        - $ref: '#/components/parameters/Vipps-System-Version'
+        - $ref: '#/components/parameters/Vipps-System-Plugin-Name'
+        - $ref: '#/components/parameters/Vipps-System-Plugin-Version'
+        - in: query
           required: true
           name: ledgerId
           schema:
@@ -197,6 +205,48 @@ components:
       schema:
         type: string
         example: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1Ni..."
+    Vipps-System-Name:
+      name: Vipps-System-Name
+      in: header
+      description: |-
+        The name of the ecommerce solution.
+        One word in lowercase letters is good.
+        See [http-headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
+      schema:
+        type: string
+        maxLength: 30
+        example: woocommerce
+    Vipps-System-Version:
+      name: Vipps-System-Version
+      in: header
+      description: |-
+        The version number of the ecommerce solution.
+        See [http-headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
+      schema:
+        type: string
+        maxLength: 30
+        example: '5.4.0'
+    Vipps-System-Plugin-Name:
+      name: Vipps-System-Plugin-Name
+      in: header
+      description: |-
+        The name of the ecommerce plugin (if applicable).
+        One word in lowercase letters is good.
+        See [http-headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
+      schema:
+        type: string
+        maxLength: 30
+        example: "vipps-woocommerce"
+    Vipps-System-Plugin-Version:
+      name: Vipps-System-Plugin-Version
+      in: header
+      description: |-
+        The version number of the ecommerce plugin (if applicable).
+        See [http-headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
+      schema:
+        type: string
+        maxLength: 30
+        example: "1.2.1"
 
   responses:
     500:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -46,6 +46,7 @@ paths:
         - $ref: '#/components/parameters/Vipps-System-Version'
         - $ref: '#/components/parameters/Vipps-System-Plugin-Name'
         - $ref: '#/components/parameters/Vipps-System-Plugin-Version'
+        - $ref: '#/components/parameters/Merchant-Serial-Number'
         - in: query
           name: settlesForRecipientHandles
           required: false
@@ -118,6 +119,7 @@ paths:
         - $ref: '#/components/parameters/Vipps-System-Version'
         - $ref: '#/components/parameters/Vipps-System-Plugin-Name'
         - $ref: '#/components/parameters/Vipps-System-Plugin-Version'
+        - $ref: '#/components/parameters/Merchant-Serial-Number'
         - in: query
           required: true
           name: ledgerId
@@ -205,6 +207,15 @@ components:
       schema:
         type: string
         example: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1Ni..."
+    Merchant-Serial-Number:
+      name: Merchant-Serial-Number
+      in: header
+      required: false
+      schema:
+        type: string
+      description: |-
+        The merchant serial number (MSN) for the sales unit. 
+        See [http-headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
     Vipps-System-Name:
       name: Vipps-System-Name
       in: header

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -9,7 +9,6 @@ servers:
   - url: https://apitest.vipps.no
   - url: https://api.vipps.no
 paths:
-
   "/settlement/v1/ledgers":
     get:
       summary: Returns the ledgers you have access to
@@ -46,7 +45,6 @@ paths:
         - $ref: '#/components/parameters/Vipps-System-Version'
         - $ref: '#/components/parameters/Vipps-System-Plugin-Name'
         - $ref: '#/components/parameters/Vipps-System-Plugin-Version'
-        - $ref: '#/components/parameters/Merchant-Serial-Number'
         - in: query
           name: settlesForRecipientHandles
           required: false
@@ -119,7 +117,6 @@ paths:
         - $ref: '#/components/parameters/Vipps-System-Version'
         - $ref: '#/components/parameters/Vipps-System-Plugin-Name'
         - $ref: '#/components/parameters/Vipps-System-Plugin-Version'
-        - $ref: '#/components/parameters/Merchant-Serial-Number'
         - in: query
           required: true
           name: ledgerId
@@ -207,15 +204,6 @@ components:
       schema:
         type: string
         example: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1Ni..."
-    Merchant-Serial-Number:
-      name: Merchant-Serial-Number
-      in: header
-      required: false
-      schema:
-        type: string
-      description: |-
-        The merchant serial number (MSN) for the sales unit. 
-        See [http-headers](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).
     Vipps-System-Name:
       name: Vipps-System-Name
       in: header


### PR DESCRIPTION
Add in headers according to [this documentation](https://developer.vippsmobilepay.com/docs/vipps-developers/common-topics/http-headers).

Correct location of `ledgerId` parameter from 'path' to 'query'